### PR TITLE
Can move

### DIFF
--- a/main.js
+++ b/main.js
@@ -42,10 +42,10 @@ class Game {
 
 
         // canMoveの動作チェック
-        console.log(this.field.canMove(this.currentTetromino.x, this.currentTetromino.y, 0, 1, this.currentTetromino.tetro));
+        console.log(this.checkCanMove(0, 1));
 
         // 仮にy座標を+1ずつする
-        if (!this.field.canMove(this.currentTetromino.x, this.currentTetromino.y, 0, 1, this.currentTetromino.tetro)) {
+        if (!this.checkCanMove(0, 1)) {
             return;
         }
         this.currentTetromino.y += 1;
@@ -58,6 +58,10 @@ class Game {
 
     checkGameOver(){
 
+    }
+
+    checkCanMove(movementX, movementY) {
+        return this.field.canMove(this.currentTetromino.x, this.currentTetromino.y, movementX, movementY, this.currentTetromino.tetro);
     }
 }
 

--- a/main.js
+++ b/main.js
@@ -41,12 +41,13 @@ class Game {
         // もし次移動する場所がブロックまたは床だったら、fieldにテトロを追加
 
 
-
-
-
+        // canMoveの動作チェック
+        console.log(this.field.canMove(this.currentTetromino.x, this.currentTetromino.y, 0, 1, this.currentTetromino.tetro));
 
         // 仮にy座標を+1ずつする
-        if (!this.field.canMove(this.currentTetromino.x, this.currentTetromino.y, 0, 1, this.currentTetromino)) return;
+        if (!this.field.canMove(this.currentTetromino.x, this.currentTetromino.y, 0, 1, this.currentTetromino.tetro)) {
+            return;
+        }
         this.currentTetromino.y += 1;
 
         this.renderer.clear();


### PR DESCRIPTION
グローバルでキーイベントの実装をする時
グローバルからcanMoveを呼び出すのにあまりにも長文になってしまうため
例）game.field.canMove(this.currentTetromino.x, this.currentTetromino.y, 1, 0, this.currentTetromino);
class Game内にcheckCanMoveを作成

結局、関数の数が増えるので意見もらいたいです。